### PR TITLE
Fix RolePermissionSeeder logic for adding permissions post-initial se…

### DIFF
--- a/database/seeds/RolePermissionSeeder.php
+++ b/database/seeds/RolePermissionSeeder.php
@@ -83,6 +83,8 @@ class RolePermissionSeeder extends Seeder
                     // profile Permissions
                     'profile.view',
                     'profile.edit',
+                    'profile.delete',
+                    'profile.update',
                 ]
             ],
         ];
@@ -100,21 +102,29 @@ class RolePermissionSeeder extends Seeder
         // }
 
         // Do same for the admin guard for tutorial purposes
-        $roleSuperAdmin = Role::create(['name' => 'superadmin', 'guard_name' => 'admin']);
+        $admin = Admin::where('username', 'superadmin')->first();
+        if(is_null($admin)){
+            $roleSuperAdmin = Role::create(['name' => 'superadmin', 'guard_name' => 'admin']);
+        }else{
+            $roleSuperAdmin = Role::where('name','superadmin')->first();
+        }
+        
 
         // Create and Assign Permissions
         for ($i = 0; $i < count($permissions); $i++) {
             $permissionGroup = $permissions[$i]['group_name'];
             for ($j = 0; $j < count($permissions[$i]['permissions']); $j++) {
-                // Create Permission
-                $permission = Permission::create(['name' => $permissions[$i]['permissions'][$j], 'group_name' => $permissionGroup, 'guard_name' => 'admin']);
-                $roleSuperAdmin->givePermissionTo($permission);
-                $permission->assignRole($roleSuperAdmin);
+                $permissionExist = Permission::where('name', $permissions[$i]['permissions'][$j])->first();
+                if(is_null($permissionExist)){
+                    $permission = Permission::create(['name' => $permissions[$i]['permissions'][$j], 'group_name' => $permissionGroup, 'guard_name' => 'admin']);
+                    $roleSuperAdmin->givePermissionTo($permission);
+                    $permission->assignRole($roleSuperAdmin);
+                }
+
             }
         }
 
         // Assign super admin role permission to superadmin user
-        $admin = Admin::where('username', 'superadmin')->first();
         if ($admin) {
             $admin->assignRole($roleSuperAdmin);
         }


### PR DESCRIPTION
### Issue
Fixes #52

### Problem
Encountered an issue where permissions couldn't be added to roles after the initial seeding process in the RolePermissionSeeder file.

### Solution
Updated the RolePermissionSeeder logic to correctly handle the addition of permissions post-initial seeding. This ensures that roles can now be modified to include additional permissions as needed.

