### PR TITLE
fix(media): use 'media.create' in MediaPolicy::create() and update tests 

### DIFF
--- a/app/Policies/MediaPolicy.php
+++ b/app/Policies/MediaPolicy.php
@@ -30,7 +30,7 @@ class MediaPolicy extends BasePolicy
      */
     public function create(User $user): bool
     {
-        return $this->checkPermission($user, 'media.upload');
+        return $this->checkPermission($user, 'media.create');
     }
 
     /**

--- a/tests/Feature/Policies/MediaPolicyTest.php
+++ b/tests/Feature/Policies/MediaPolicyTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Policies;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MediaPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function user_with_media_create_can_create(): void
+    {
+        $user = User::factory()->create();
+
+        \Spatie\Permission\Models\Permission::firstOrCreate([
+            'name' => 'media.create',
+            'guard_name' => 'web',
+        ]);
+
+        $user->givePermissionTo('media.create');
+
+        $policy = app(\App\Policies\MediaPolicy::class);
+        $this->assertTrue($policy->create($user));
+    }
+
+    /** @test */
+    public function user_without_media_create_cannot_create(): void
+    {
+        $user = User::factory()->create();
+
+        $policy = app(\App\Policies\MediaPolicy::class);
+        $this->assertFalse($policy->create($user));
+    }
+}


### PR DESCRIPTION
## What
- Replace `media.upload` → `media.create` in MediaPolicy::create()
- Add/adjust tests to assert `media.create` is required to create media

## Why
- Align permission name with the intended capability ("create" is the canonical name)
- Prevent users who only had the legacy `media.upload` from passing `create` gate unintentionally

## Notes
- Grepped repo and updated all remaining references of `media.upload` (if any)
- All tests green locally