### PR TITLE
Fix Privilege Escalation via Role Assignment and User Impersonation

### DIFF
--- a/app/Http/Controllers/Backend/UserLoginAsController.php
+++ b/app/Http/Controllers/Backend/UserLoginAsController.php
@@ -8,28 +8,74 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Session;
 
 class UserLoginAsController extends Controller
 {
     public function loginAs(int $id): RedirectResponse
     {
-        $user = User::findOrFail($id);
-        $this->authorize('loginAs', $user);
+        $currentUser = Auth::user();
+        $targetUser = User::findOrFail($id);
 
-        Session::put('original_user_id', auth()->id());
-        Auth::login($user);
+        if (! $currentUser) {
+            abort(403);
+        }
 
-        session()->flash('success', __('You are now logged in as :name.', ['name' => $user->full_name]));
+        $this->authorize('loginAs', $targetUser);
+
+        if ($currentUser->id === $targetUser->id) {
+            abort(403, __('You cannot impersonate your own account.'));
+        }
+
+        if (
+            $targetUser->hasRole('Superadmin')
+            && ! $currentUser->hasRole('Superadmin')
+        ) {
+            Log::warning('Blocked Superadmin impersonation attempt.', [
+                'actor_user_id' => $currentUser->id,
+                'target_user_id' => $targetUser->id,
+                'actor_email' => $currentUser->email,
+                'target_email' => $targetUser->email,
+                'ip' => request()->ip(),
+            ]);
+
+            abort(403, __('You are not allowed to impersonate a Superadmin user.'));
+        }
+
+        Session::put('original_user_id', $currentUser->id);
+
+        Log::info('User impersonation started.', [
+            'actor_user_id' => $currentUser->id,
+            'target_user_id' => $targetUser->id,
+            'actor_email' => $currentUser->email,
+            'target_email' => $targetUser->email,
+            'ip' => request()->ip(),
+        ]);
+
+        Auth::login($targetUser);
+
+        session()->flash('success', __('You are now logged in as :name.', [
+            'name' => $targetUser->full_name,
+        ]));
 
         return redirect()->route('admin.dashboard');
     }
 
     public function switchBack(): RedirectResponse
     {
+        $impersonatedUser = Auth::user();
         $originalUserId = session()->pull('original_user_id');
+
         if ($originalUserId) {
+            Log::info('User impersonation ended.', [
+                'original_user_id' => $originalUserId,
+                'impersonated_user_id' => $impersonatedUser?->id,
+                'ip' => request()->ip(),
+            ]);
+
             Auth::loginUsingId($originalUserId);
+
             session()->flash('success', __('Switched back to the original user.'));
         }
 

--- a/app/Http/Requests/User/StoreUserRequest.php
+++ b/app/Http/Requests/User/StoreUserRequest.php
@@ -17,7 +17,7 @@ class StoreUserRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return true;
+        return auth()->user()?->can('create', User::class) ?? false;
     }
 
     /**

--- a/app/Http/Requests/User/StoreUserRequest.php
+++ b/app/Http/Requests/User/StoreUserRequest.php
@@ -6,7 +6,9 @@ namespace App\Http\Requests\User;
 
 use App\Enums\Hooks\UserFilterHook;
 use App\Http\Requests\FormRequest;
+use App\Models\User;
 use App\Support\Facades\Hook;
+use Illuminate\Validation\Rule;
 
 class StoreUserRequest extends FormRequest
 {
@@ -15,7 +17,6 @@ class StoreUserRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        // Authorization is handled by the controller using policies
         return true;
     }
 
@@ -46,7 +47,18 @@ class StoreUserRequest extends FormRequest
 
             /** @example [1, 2, 3] */
             'roles' => 'nullable|array',
-            'roles.*' => 'nullable|exists:roles,name',
+            'roles.*' => [
+                'nullable',
+                Rule::exists('roles', 'name'),
+                function ($attribute, $value, $fail) {
+                    if (
+                        strtolower((string) $value) === 'superadmin'
+                        && ! auth()->user()?->hasRole('Superadmin')
+                    ) {
+                        $fail(__('You are not allowed to assign the Superadmin role.'));
+                    }
+                },
+            ],
         ]);
     }
 }

--- a/app/Http/Requests/User/UpdateUserRequest.php
+++ b/app/Http/Requests/User/UpdateUserRequest.php
@@ -17,8 +17,7 @@ class UpdateUserRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        // Authorization is handled by the controller using policies
-        return true;
+        return auth()->user()?->can('update', User::find(request()->route('user'))) ?? false;
     }
 
     /**

--- a/app/Http/Requests/User/UpdateUserRequest.php
+++ b/app/Http/Requests/User/UpdateUserRequest.php
@@ -7,6 +7,8 @@ namespace App\Http\Requests\User;
 use App\Enums\Hooks\UserFilterHook;
 use App\Http\Requests\FormRequest;
 use App\Support\Facades\Hook;
+use App\Models\User;
+use Illuminate\Validation\Rule;
 
 class UpdateUserRequest extends FormRequest
 {
@@ -29,6 +31,15 @@ class UpdateUserRequest extends FormRequest
         // Get user ID from the request parameters
         $userId = request()->route('user');
 
+        $targetUser = User::find($userId);
+
+        if (
+            $targetUser?->hasRole('Superadmin')
+            && ! auth()->user()?->hasRole('Superadmin')
+        ) {
+            abort(403, __('You are not allowed to modify a Superadmin user.'));
+        }
+
         return Hook::applyFilters(UserFilterHook::USER_UPDATE_VALIDATION_RULES, [
             /** @example "Jane" */
             'first_name' => 'required|max:50',
@@ -50,7 +61,18 @@ class UpdateUserRequest extends FormRequest
 
             /** @example [1, 2, 3] */
             'roles' => 'nullable|array',
-            'roles.*' => 'nullable|exists:roles,name',
+            'roles.*' => [
+                'nullable',
+                Rule::exists('roles', 'name'),
+                function ($attribute, $value, $fail) {
+                    if (
+                        strtolower((string) $value) === 'superadmin'
+                        && ! auth()->user()?->hasRole('Superadmin')
+                    ) {
+                        $fail(__('You are not allowed to assign the Superadmin role.'));
+                    }
+                },
+            ],
         ], $userId);
     }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -105,7 +105,30 @@ class UserPolicy extends BasePolicy
      */
     public function loginAs(User $user, User $model): bool
     {
-        return $this->checkPermission($user, 'user.login_as');
+        // User cannot impersonate themselves.
+        if ($user->id === $model->id) {
+            return false;
+        }
+
+        // Must have impersonation permission.
+        if (! $this->checkPermission($user, 'user.login_as')) {
+            return false;
+        }
+
+        $userIsSuperadmin = $user->hasRole('Superadmin');
+        $targetIsSuperadmin = $model->hasRole('Superadmin');
+
+        // Non-Superadmin users cannot impersonate Superadmin.
+        if ($targetIsSuperadmin && ! $userIsSuperadmin) {
+            return false;
+        }
+
+        // Superadmin can impersonate anybody
+        if ($userIsSuperadmin) {
+            return true;
+        }
+
+        return true;
     }
 
     /**

--- a/app/Services/RolesService.php
+++ b/app/Services/RolesService.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Collection;
 use Spatie\Permission\Models\Permission;
 use App\Models\Role;
+use Illuminate\Support\Facades\Auth;
 
 class RolesService
 {
@@ -22,7 +23,13 @@ class RolesService
 
     public function getRolesDropdown(): array
     {
-        return Role::pluck('name', 'name')->toArray();
+        $query = Role::query();
+
+        if (! Auth::user()?->hasRole('Superadmin')) {
+            $query->where('name', '!=', 'Superadmin');
+        }
+
+        return $query->pluck('name', 'name')->toArray();
     }
 
     public function getPaginatedRoles(?string $search = null, int $perPage = 10): LengthAwarePaginator
@@ -265,7 +272,7 @@ class RolesService
         $roleName = strtolower($roleName);
 
         switch ($roleName) {
-            case 'Superadmin':
+            case 'superadmin':
                 // All permissions.
                 $allPermissionNames = [];
                 foreach ($this->permissionService->getAllPermissions() as $group) {
@@ -276,7 +283,7 @@ class RolesService
 
                 return $allPermissionNames;
 
-            case 'Admin':
+            case 'admin':
                 // All except some critical permissions.
                 $adminExcludedPermissions = [
                     'user.delete',
@@ -290,7 +297,7 @@ class RolesService
 
                 return array_diff($allPermissionNames, $adminExcludedPermissions);
 
-            case 'Editor':
+            case 'editor':
                 return [
                     'dashboard.view',
                     'blog.create',
@@ -308,8 +315,8 @@ class RolesService
                     'term.create',
                 ];
 
-            case 'Subscriber':
-            case 'Contact':
+            case 'subscriber':
+            case 'contact':
                 return [
                     'dashboard.view',
                     'profile.view',

--- a/app/Services/RolesService.php
+++ b/app/Services/RolesService.php
@@ -269,10 +269,9 @@ class RolesService
      */
     public function getPredefinedRolePermissions(string $roleName): array
     {
-        $roleName = strtolower($roleName);
 
         switch ($roleName) {
-            case 'superadmin':
+            case 'Superadmin':
                 // All permissions.
                 $allPermissionNames = [];
                 foreach ($this->permissionService->getAllPermissions() as $group) {
@@ -283,7 +282,7 @@ class RolesService
 
                 return $allPermissionNames;
 
-            case 'admin':
+            case 'Admin':
                 // All except some critical permissions.
                 $adminExcludedPermissions = [
                     'user.delete',
@@ -297,7 +296,7 @@ class RolesService
 
                 return array_diff($allPermissionNames, $adminExcludedPermissions);
 
-            case 'editor':
+            case 'Editor':
                 return [
                     'dashboard.view',
                     'blog.create',
@@ -315,8 +314,8 @@ class RolesService
                     'term.create',
                 ];
 
-            case 'subscriber':
-            case 'contact':
+            case 'Subscriber':
+            case 'Contact':
                 return [
                     'dashboard.view',
                     'profile.view',

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
 use InvalidArgumentException;
 
 class UserService
@@ -31,6 +32,31 @@ class UserService
         $this->syncUserRoles($user, $data);
 
         return $user;
+    }
+
+    private function ensureCanManageRoles(User $targetUser, array $roles): void
+    {
+        $authUser = Auth::user();
+
+        if (! $authUser) {
+            abort(403);
+        }
+
+        $isSuperadmin = $authUser->hasRole('Superadmin');
+
+        // Prevent non-superadmin from modifying an existing superadmin user.
+        if ($targetUser->hasRole('Superadmin') && ! $isSuperadmin) {
+            abort(403, __('You are not allowed to modify a Superadmin user.'));
+        }
+
+        // Prevent non-superadmin from assigning superadmin role.
+        $requestedRoles = collect($roles)
+            ->filter()
+            ->map(fn ($role) => strtolower((string) $role));
+
+        if ($requestedRoles->contains('Superadmin') && ! $isSuperadmin) {
+            abort(403, __('You are not allowed to assign Superadmin role.'));
+        }
     }
 
     public function pluck(string ...$columns): Collection
@@ -157,6 +183,7 @@ class UserService
     private function syncUserRoles(User $user, array $data): void
     {
         if (isset($data['roles'])) {
+            $this->ensureCanManageRoles($user, $data['roles']);
             $user->syncRoles($data['roles']);
         }
     }
@@ -209,6 +236,8 @@ class UserService
 
         $filteredRoles = array_filter($roles);
 
+        $this->ensureCanManageRoles($user, $filteredRoles);
+
         if (! empty($filteredRoles)) {
             $user->syncRoles($filteredRoles);
         }
@@ -216,6 +245,8 @@ class UserService
 
     private function updateUserRoles(User $user, array $roles): void
     {
+        $this->ensureCanManageRoles($user, $roles);
+
         $user->roles()->detach();
         $this->assignUserRoles($user, $roles);
     }
@@ -288,7 +319,7 @@ class UserService
         $deletedCount = 0;
 
         foreach ($users as $user) {
-            if ($user->hasRole('superadmin')) {
+            if ($user->hasRole('Superadmin')) {
                 continue;
             }
             if ($currentUserId && $user->id == $currentUserId) {

--- a/bootstrap/cache/mod12A8.tmp
+++ b/bootstrap/cache/mod12A8.tmp
@@ -1,0 +1,13 @@
+<?php return array (
+  'providers' => 
+  array (
+    0 => 'Modules\\Crm\\Providers\\CrmServiceProvider',
+  ),
+  'eager' => 
+  array (
+    0 => 'Modules\\Crm\\Providers\\CrmServiceProvider',
+  ),
+  'deferred' => 
+  array (
+  ),
+);

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -2,5 +2,5 @@
     "crm": true,
     "DocForge": false,
     "Starter26": false,
-    "customform": false
+    "customform": true
 }

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -1,6 +1,6 @@
 {
     "crm": true,
-    "DocForge": true,
-    "Starter26": true,
-    "customform": true
+    "DocForge": false,
+    "Starter26": false,
+    "customform": false
 }


### PR DESCRIPTION
fix(security): mitigate Superadmin privilege escalation vulnerability

- Enforce server-side authorization for role assignment
- Block non-Superadmin users from assigning Superadmin role
- Prevent modification of Superadmin accounts by lower-privileged users
- Filter Superadmin role from non-Superadmin role dropdowns
- Add validation safeguards against privilege escalation attempts
- Harden user create/update workflows against role mass assignment

fix(security): harden user impersonation authorization

- Prevent non-Superadmin users from impersonating Superadmin accounts
- Add target-user authorization checks to loginAs policy
- Block self-impersonation attempts
- Add impersonation audit logging for security monitoring
- Improve impersonation flow and redirect handling
- Mitigate privilege escalation via user.login_as permission

<img width="1912" height="903" alt="image" src="https://github.com/user-attachments/assets/3a5b9926-a779-477d-86ea-ac156904a7d2" />
