### PR TITLE
fix(media): stop x-data attribute breaking out of its quotes

### DIFF
--- a/app/Support/Helper/MediaHelper.php
+++ b/app/Support/Helper/MediaHelper.php
@@ -229,7 +229,7 @@ class MediaHelper
 
         // Check if POST was truncated due to post_max_size
         if (
-            $_SERVER['REQUEST_METHOD'] === 'POST' &&
+            ($_SERVER['REQUEST_METHOD'] ?? null) === 'POST' &&
             empty($_POST) &&
             empty($_FILES) &&
             isset($_SERVER['CONTENT_LENGTH']) &&

--- a/resources/views/backend/pages/media/index.blade.php
+++ b/resources/views/backend/pages/media/index.blade.php
@@ -1,69 +1,68 @@
+<x-layouts.backend-layout :breadcrumbs="$breadcrumbs">
+    <div
+        x-data="{
+            selectedMedia: [],
+            selectAll: false,
+            bulkDeleteModalOpen: false,
+            typeDropdownOpen: false,
+            bulkActionsDropdownOpen: false,
+            viewMode: localStorage.getItem('mediaViewMode') || 'grid',
+            uploadModalOpen: false,
 
-<div
-    x-data="{
-        selectedMedia: [],
-        selectAll: false,
-        bulkDeleteModalOpen: false,
-        typeDropdownOpen: false,
-        bulkActionsDropdownOpen: false,
-        viewMode: localStorage.getItem('mediaViewMode') || 'grid',
-        uploadModalOpen: false,
+            init() {
+                // Auto-open upload modal if ?new is in URL
+                const urlParams = new URLSearchParams(window.location.search);
+                if (urlParams.has('new')) {
+                    this.uploadModalOpen = true;
+                }
 
-        init() {
-            // Auto-open upload modal if ?new is in URL
-            const urlParams = new URLSearchParams(window.location.search);
-            if (urlParams.has('new')) {
-                this.uploadModalOpen = true;
-            }
+                const autoSelectRaw = sessionStorage.getItem('mediaLibraryAutoSelect');
+                if (autoSelectRaw) {
+                    sessionStorage.removeItem('mediaLibraryAutoSelect');
 
-            const autoSelectRaw = sessionStorage.getItem('mediaLibraryAutoSelect');
-            if (autoSelectRaw) {
-                sessionStorage.removeItem('mediaLibraryAutoSelect');
+                    try {
+                        const uploadedIds = JSON.parse(autoSelectRaw).map(String);
+                        if (uploadedIds.length > 0) {
+                            this.selectedMedia = uploadedIds;
 
-                try {
-                    const uploadedIds = JSON.parse(autoSelectRaw).map(String);
-                    if (uploadedIds.length > 0) {
-                        this.selectedMedia = uploadedIds;
-
-                        this.$nextTick(() => {
-                            const lastId = uploadedIds[uploadedIds.length - 1];
-                            const target = document.querySelector(`[data-media-id="${lastId}"]`);
-                            target?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-                        });
+                            this.$nextTick(() => {
+                                const lastId = uploadedIds[uploadedIds.length - 1];
+                                const target = document.querySelector(`[data-media-id='${lastId}']`);
+                                target?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+                            });
+                        }
+                    } catch (error) {
+                        console.error('Failed to restore uploaded media selection:', error);
                     }
-                } catch (error) {
-                    console.error('Failed to restore uploaded media selection:', error);
                 }
-            }
 
-            // Watch for modal close and remove ?new from URL
-            this.$watch('uploadModalOpen', (value) => {
-                if (!value) {
-                    this.removeNewParam();
+                // Watch for modal close and remove ?new from URL
+                this.$watch('uploadModalOpen', (value) => {
+                    if (!value) {
+                        this.removeNewParam();
+                    }
+                });
+            },
+
+            removeNewParam() {
+                const url = new URL(window.location.href);
+                if (url.searchParams.has('new')) {
+                    url.searchParams.delete('new');
+                    window.history.replaceState({}, '', url.toString());
                 }
-            });
-        },
+            },
 
-        removeNewParam() {
-            const url = new URL(window.location.href);
-            if (url.searchParams.has('new')) {
-                url.searchParams.delete('new');
-                window.history.replaceState({}, '', url.toString());
+            toggleViewMode() {
+                this.viewMode = this.viewMode === 'grid' ? 'list' : 'grid';
+                localStorage.setItem('mediaViewMode', this.viewMode);
+            },
+
+            showSingleDeleteModal(id) {
+                this.selectedMedia = [id.toString()];
+                this.bulkDeleteModalOpen = true;
             }
-        },
-
-        toggleViewMode() {
-            this.viewMode = this.viewMode === 'grid' ? 'list' : 'grid';
-            localStorage.setItem('mediaViewMode', this.viewMode);
-        },
-
-        showSingleDeleteModal(id) {
-            this.selectedMedia = [id.toString()];
-            this.bulkDeleteModalOpen = true;
-        }
-    }" id="mediaManager"
->
-    <x-layouts.backend-layout :breadcrumbs="$breadcrumbs">
+        }" id="mediaManager"
+    >
         {!! Hook::applyFilters(CommonFilterHook::MEDIA_AFTER_BREADCRUMBS, '') !!}
 
         @if ($errors->any())
@@ -863,5 +862,5 @@
                 }
             </script>
         @endpush
-    </x-layouts.backend-layout>
-</div>
+    </div>
+</x-layouts.backend-layout>

--- a/tests/Feature/View/MediaIndexMarkupTest.php
+++ b/tests/Feature/View/MediaIndexMarkupTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+
+pest()->use(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+
+    Permission::firstOrCreate(['name' => 'media.view', 'guard_name' => 'web']);
+    $this->user->givePermissionTo('media.view');
+});
+
+test('media index page loads', function () {
+    $response = $this->actingAs($this->user)->get(route('admin.media.index'));
+
+    $response->assertOk();
+    $response->assertSee(__('Media Library'));
+});
+
+test('media index does not break out of the x-data attribute', function () {
+    // A double quote inside the double-quoted x-data attribute terminates it early,
+    // which kills the Alpine component and leaks the rest of the JS as page text.
+    $response = $this->actingAs($this->user)->get(route('admin.media.index'));
+
+    $response->assertOk();
+
+    $previous = libxml_use_internal_errors(true);
+    $dom = new DOMDocument();
+    $dom->loadHTML($response->getContent());
+    libxml_clear_errors();
+    libxml_use_internal_errors($previous);
+
+    $root = $dom->getElementById('mediaManager');
+    expect($root)->not->toBeNull();
+
+    // The last member of the Alpine object survives only if the attribute never
+    // got cut short, so this proves the whole expression made it through intact.
+    $xData = $root->getAttribute('x-data');
+    expect($xData)
+        ->toContain('showSingleDeleteModal(id)')
+        ->and(rtrim($xData))->toEndWith('}');
+});
+
+test('media index emits the doctype first', function () {
+    // The Alpine wrapper must live inside the layout component: any element emitted
+    // before <!DOCTYPE html> puts the browser into quirks mode.
+    $response = $this->actingAs($this->user)->get(route('admin.media.index'));
+
+    $response->assertOk();
+    expect(strtolower(ltrim($response->getContent())))->toStartWith('<!doctype html');
+});


### PR DESCRIPTION

<img width="1351" height="729" alt="Capture" src="https://github.com/user-attachments/assets/51c96294-81f2-48f9-8074-6caf2bb3d8c1" />
The Alpine root on the media library page used a template literal with double quotes inside the double-quoted x-data attribute:

    document.querySelector(`[data-media-id="${lastId}"]`)

The tokenizer terminated the attribute at that quote, consumed the rest of the expression as bogus attribute names, then closed the tag at the `=` of `(value) =>`. Everything after leaked onto the page as text and the truncated expression left Alpine unable to evaluate the component, so selection, bulk delete, the view toggle and the upload modal were all dead.

Switch the selector to single quotes, and move the x-data wrapper inside <x-layouts.backend-layout> — it previously wrapped the component from the outside, emitting a <div> ahead of <!DOCTYPE html> and forcing the browser into quirks mode.

Also guard $_SERVER['REQUEST_METHOD'] in MediaHelper::checkPhpUploadError(); it is always set under the web SAPI but undefined in tests, which made the page impossible to render under PHPUnit.

Add MediaIndexMarkupTest, which parses the response and asserts #mediaManager carries a complete x-data attribute and that the doctype is emitted first.